### PR TITLE
Adjust Navigation Stack and Add firebase auth test to Splash screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,8 +1,10 @@
 import 'react-native-gesture-handler';
 import * as React from 'react';
+import { useState, useEffect } from 'react'
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import AsyncStorage from '@react-native-community/async-storage';
+import auth from '@react-native-firebase/auth';
 
 import GoalScreen from './screens/GoalScreen';
 import HomeScreen from './screens/HomeScreen';
@@ -93,35 +95,36 @@ export default function App({ navigation }) {
     []
   );
 */
+
+  //Add Authentication piece following guide here: https://rnfirebase.io/auth/usage
+  const [initializing, setInitializing] = useState(true);
+  const [user, setUser] = useState();
+
+  function onAuthStateChanged(user) {
+    setUser(user);
+    if (initializing) setInitializing(false);
+  }
+
+  useEffect(() => {
+    const subscriber = auth().onAuthStateChanged(onAuthStateChanged);
+    return subscriber; // unsubscribe on unmount
+  }, []);
+
+  if (initializing) return null;
+
+/*
+  if (!user) {
+      return (
+        <View>
+          <Text>Login</Text>
+        </View>
+      );
+    }
+*/
   return (
     //<AuthContext.Provider value={authContext}>
     <NavigationContainer>
         <Stack.Navigator initialRouteName="Splash">
-          /*{state.isLoading ? (
-            // We haven't finished checking for the token yet
-            <Stack.Screen 
-              name="Splash"
-              component={SplashScreen}
-              options={{headerShown: false}} 
-            />
-          ) : state.userToken == null ? (
-            // No token found, user isn't signed in
-            <Stack.Screen
-              name="Login"
-              component={LoginScreen}
-              options={{ 
-                headerShown: false,
-                animationTypeForReplace: state.isSignout ? 'pop' : 'push',
-              }}
-            />
-          ) : (
-            // User is signed in
-            <Stack.Screen 
-              name="Home" 
-              component={HomeScreen} 
-            />
-          )}
-          */
             <Stack.Screen
               name="Splash"
               component={SplashScreen}
@@ -134,29 +137,19 @@ export default function App({ navigation }) {
               options={{ headerShown: false }}
             />
 
-          <StackScreen
+          <Stack.Screen
             name="Home"
             component={HomeScreen}
           />
 
-          <StackScreen
-            name="Profile"
-            component={ProfileScreen}
-          />
-
-          <StackScreen
+          <Stack.Screen
             name="Goal"
             component={GoalScreen}
           />
 
-          <StackScreen
+          <Stack.Screen
             name="SetNewGoal"
             component={SetANewGoalScreen}
-          />
-
-          <StackScreen
-            name="InHike"
-            component={InHikeScreen}
           />
         </Stack.Navigator>
     </NavigationContainer>

--- a/App.js
+++ b/App.js
@@ -1,5 +1,5 @@
 import 'react-native-gesture-handler';
-import * as React from 'react'
+import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import AsyncStorage from '@react-native-community/async-storage';
@@ -13,10 +13,12 @@ import SetANewGoalScreen from './screens/SetANewGoalScreen';
 import SplashScreen from './screens/SplashScreen';
 
 
-const AuthContext = React.createContext();
+//const AuthContext = React.createContext();
 const Stack = createStackNavigator();
 
 export default function App({ navigation }) {
+
+/*
   const [state, dispatch] = React.useReducer(
     (prevState, action) => {
       switch (action.type) {
@@ -90,12 +92,12 @@ export default function App({ navigation }) {
     }),
     []
   );
-
+*/
   return (
-    <AuthContext.Provider value={authContext}>
-      <NavigationContainer>
-        <Stack.Navigator>
-          {state.isLoading ? (
+    //<AuthContext.Provider value={authContext}>
+    <NavigationContainer>
+        <Stack.Navigator initialRouteName="Splash">
+          /*{state.isLoading ? (
             // We haven't finished checking for the token yet
             <Stack.Screen 
               name="Splash"
@@ -119,8 +121,45 @@ export default function App({ navigation }) {
               component={HomeScreen} 
             />
           )}
+          */
+            <Stack.Screen
+              name="Splash"
+              component={SplashScreen}
+              options={{headerShown: false}}
+            />
+
+            <Stack.Screen
+              name="Login"
+              component={LoginScreen}
+              options={{ headerShown: false }}
+            />
+
+          <StackScreen
+            name="Home"
+            component={HomeScreen}
+          />
+
+          <StackScreen
+            name="Profile"
+            component={ProfileScreen}
+          />
+
+          <StackScreen
+            name="Goal"
+            component={GoalScreen}
+          />
+
+          <StackScreen
+            name="SetNewGoal"
+            component={SetANewGoalScreen}
+          />
+
+          <StackScreen
+            name="InHike"
+            component={InHikeScreen}
+          />
         </Stack.Navigator>
-      </NavigationContainer>
-    </AuthContext.Provider>
+    </NavigationContainer>
+    //</AuthContext.Provider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10407,15 +10407,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-2.11.0.tgz",
       "integrity": "sha512-vJzJE3zI1XUtqthrX3Dh2TBQWB+xFyaGhF52KBq9FjJUN5ws4xpLZJxBWa1KbGV3DilmcSZ4jmZR5LGordwE7w=="
     },
-    "react-navigation-stack": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/react-navigation-stack/-/react-navigation-stack-2.8.4.tgz",
-      "integrity": "sha512-9ZZ52s6URWoXdTTU/BLEJwYiIFiIRZZF+GEfuLmM8I2w7RBxa0y01ylhL7bVy3aY0Gt/eCbBzslC/4sdRQFFKw==",
-      "requires": {
-        "color": "^3.1.2",
-        "react-native-iphone-x-helper": "^1.2.1"
-      }
-    },
     "react-refresh": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "react-native-gesture-handler": "^1.8.0",
     "react-native-reanimated": "^1.13.1",
     "react-native-safe-area-context": "^3.1.8",
-    "react-native-screens": "^2.11.0",
-    "react-navigation-stack": "^2.8.4"
+    "react-native-screens": "^2.11.0"
   },
   "devDependencies": {
     "@babel/core": "7.11.6",

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component, useState, useEffect } from 'react';
 import { 
     View, 
     Image, 
@@ -8,8 +8,14 @@ import {
 } from 'react-native';
 import { TextInput } from 'react-native-gesture-handler';
 import logo from '../images/logo.png';
+import auth from '@react-native-firebase/auth';
 
 class LoginScreen extends Component {
+    handleUserLogin = () => {
+        //TO do - add login steps
+        console.log('handleLogin')
+    }
+
     render() {
         return (
             <>

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -10,14 +10,13 @@ import {
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import logo from '../images/logo.png';
-import firebase from 'react-native-firebase'; //Needed to for authentication check
+import auth, { firebase } from '@react-native-firebase/auth';//Needed to for authentication check
 
 class SplashScreen extends Component {
-    //Guide to check auth state on load included here:
-    //https://medium.com/better-programming/react-native-firebase-authentication-7652e1d2c8a2
-    componentDidMount(){
+    componentDidMount() {
         firebase.auth().onAuthStateChanged(user => {
-            this.props.navigation.navigate(user ? 'Home' : 'Login')})
+            this.props.navigation.navigate(user ? "Home" : "Login");
+        });
     }
 
     render() {

--- a/screens/SplashScreen.js
+++ b/screens/SplashScreen.js
@@ -3,13 +3,23 @@ import FadeInView from '../components/FadeInView';
 import { 
     View,
     Image, 
-    Text, 
+    Text,
     StyleSheet, 
     Animated 
 } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
 import logo from '../images/logo.png';
+import firebase from 'react-native-firebase'; //Needed to for authentication check
 
 class SplashScreen extends Component {
+    //Guide to check auth state on load included here:
+    //https://medium.com/better-programming/react-native-firebase-authentication-7652e1d2c8a2
+    componentDidMount(){
+        firebase.auth().onAuthStateChanged(user => {
+            this.props.navigation.navigate(user ? 'Home' : 'Login')})
+    }
+
     render() {
         return (
             <View style={styles.container}>


### PR DESCRIPTION
App.js:
-Added import for useState and useEffect from 'react'
-Added import for auth from '@react-native-firebase/auth'
-Adjusted Stack navigator to remove Async sign in state(commented out)
-Added initialRouteName prop to stack to ensure Splash screen launches first

Splash Screen:
-Imported ActivityIndicator from 'react-native'
-Imported auth and firebase from '@react-native-firebase/auth'
-Added componentDidMount() method to test if User is logged in, navigates to Home is yes, Splash if no

Login Screen:
-Imported useState and useEffect form 'react'
-Added handleLogIn method to be implemented later